### PR TITLE
Adds in initial step building for CollectionTemplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
   - 2.3.2
+before_script:
+  - RAILS_ENV=test bundle exec rake db:migrate
 # sudo: false Leaving this commented out, as we may need this to install the correct python version etc.

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 group :test do
   gem 'factory_girl_rails', '~> 4.0'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'config'
 
 gem 'riiif' # IIIF image server
 
+gem 'wicked' # For step by step form creation
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ end
 group :test do
   gem 'factory_girl_rails', '~> 4.0'
   gem 'rails-controller-testing'
+  gem 'capybara'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -206,6 +210,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   riiif
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,9 +38,18 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     builder (3.2.2)
     byebug (9.0.6)
+    capybara (2.10.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     codecov (0.1.8)
       json
       simplecov
@@ -96,6 +105,7 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    public_suffix (2.0.4)
     puma (3.6.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -195,12 +205,15 @@ GEM
     websocket-extensions (0.1.2)
     wicked (1.3.1)
       railties (>= 3.0.7)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  capybara
   codecov
   coffee-rails (~> 4.2)
   config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    wicked (1.3.1)
+      railties (>= 3.0.7)
 
 PLATFORMS
   ruby
@@ -213,6 +215,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  wicked
 
 BUNDLED WITH
    1.13.6

--- a/app/controllers/collection_templates/build_controller.rb
+++ b/app/controllers/collection_templates/build_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+##
+# Controller responsible for directing step by step CollectionTemplate creation
+# Uses Wicked gem for most everything.
+class CollectionTemplates::BuildController < ApplicationController
+  before_action :set_collection_template, only: [:show, :update]
+  include Wicked::Wizard
+  steps(*CollectionTemplate.form_steps)
+
+  # GET /collection_templates/:collection_template_id/build/:id
+  def show
+    render_wizard
+  end
+
+  # PUT/PATCH /collection_templates/:collection_template_id/build/:id
+  def update
+    @collection_template.update(collection_template_params(step))
+    render_wizard @collection_template
+  end
+
+  def finish_wizard_path
+    collection_template_path(@collection_template)
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_collection_template
+    @collection_template = CollectionTemplate
+                           .find(params[:collection_template_id])
+  end
+
+  ##
+  # Never trust parameters from the scary internet, only allow the white list
+  # through.
+  def collection_template_params(step)
+    permitted_attributes = case step
+                           when 'select_collection'
+                             [:collection_id]
+                           when 'select_image'
+                             [:image_id]
+                           end
+    params.require(:collection_template)
+          .permit(permitted_attributes).merge(form_step: step)
+  end
+end

--- a/app/controllers/collection_templates_controller.rb
+++ b/app/controllers/collection_templates_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+##
+# Controller for CollectionTemplate resources
+class CollectionTemplatesController < ApplicationController
+  before_action :set_collection_template, only: [:show, :edit, :update, :destroy]
+
+  # GET /collection_templates
+  # GET /collection_templates.json
+  def index
+    @collection_templates = CollectionTemplate.all
+  end
+
+  # GET /collection_templates/1
+  # GET /collection_templates/1.json
+  def show
+  end
+
+  # GET /collection_templates/new
+  def new
+    @collection_template = CollectionTemplate.new
+  end
+
+  # GET /collection_templates/1/edit
+  def edit
+  end
+
+  # POST /collection_templates
+  # POST /collection_templates.json
+  def create
+    @collection_template = CollectionTemplate.new(collection_template_params)
+
+    respond_to do |format|
+      if @collection_template.save
+        format.html { redirect_to @collection_template, notice: 'Collection template was successfully created.' }
+        format.json { render :show, status: :created, location: @collection_template }
+      else
+        format.html { render :new }
+        format.json { render json: @collection_template.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /collection_templates/1
+  # PATCH/PUT /collection_templates/1.json
+  def update
+    respond_to do |format|
+      if @collection_template.update(collection_template_params)
+        format.html { redirect_to @collection_template, notice: 'Collection template was successfully updated.' }
+        format.json { render :show, status: :ok, location: @collection_template }
+      else
+        format.html { render :edit }
+        format.json { render json: @collection_template.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /collection_templates/1
+  # DELETE /collection_templates/1.json
+  def destroy
+    @collection_template.destroy
+    respond_to do |format|
+      format.html { redirect_to collection_templates_url, notice: 'Collection template was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_collection_template
+      @collection_template = CollectionTemplate.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def collection_template_params
+      params.fetch(:collection_template, {})
+    end
+end

--- a/app/controllers/collection_templates_controller.rb
+++ b/app/controllers/collection_templates_controller.rb
@@ -3,7 +3,7 @@
 ##
 # Controller for CollectionTemplate resources
 class CollectionTemplatesController < ApplicationController
-  before_action :set_collection_template, only: [:show, :edit, :update, :destroy]
+  before_action :set_collection_template, only: [:show, :destroy]
 
   # GET /collection_templates
   # GET /collection_templates.json
@@ -21,38 +21,14 @@ class CollectionTemplatesController < ApplicationController
     @collection_template = CollectionTemplate.new
   end
 
-  # GET /collection_templates/1/edit
-  def edit
-  end
-
   # POST /collection_templates
   # POST /collection_templates.json
   def create
-    @collection_template = CollectionTemplate.new(collection_template_params)
-
-    respond_to do |format|
-      if @collection_template.save
-        format.html { redirect_to @collection_template, notice: 'Collection template was successfully created.' }
-        format.json { render :show, status: :created, location: @collection_template }
-      else
-        format.html { render :new }
-        format.json { render json: @collection_template.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /collection_templates/1
-  # PATCH/PUT /collection_templates/1.json
-  def update
-    respond_to do |format|
-      if @collection_template.update(collection_template_params)
-        format.html { redirect_to @collection_template, notice: 'Collection template was successfully updated.' }
-        format.json { render :show, status: :ok, location: @collection_template }
-      else
-        format.html { render :edit }
-        format.json { render json: @collection_template.errors, status: :unprocessable_entity }
-      end
-    end
+    @collection_template = CollectionTemplate.new
+    @collection_template.save(validate: false)
+    redirect_to collection_template_build_path(
+      @collection_template, CollectionTemplate.form_steps.first
+    )
   end
 
   # DELETE /collection_templates/1
@@ -60,19 +36,27 @@ class CollectionTemplatesController < ApplicationController
   def destroy
     @collection_template.destroy
     respond_to do |format|
-      format.html { redirect_to collection_templates_url, notice: 'Collection template was successfully destroyed.' }
+      format.html do
+        redirect_to collection_templates_url,
+                    notice: 'Collection template was successfully destroyed.'
+      end
       format.json { head :no_content }
     end
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_collection_template
-      @collection_template = CollectionTemplate.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def collection_template_params
-      params.fetch(:collection_template, {})
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_collection_template
+    @collection_template = CollectionTemplate.find(params[:id])
+  end
+
+  ##
+  # Never trust parameters from the scary internet, only allow the white list
+  # through.
+  def collection_template_params
+    params
+      .require(:collection_template)
+      .permit(:collection_id, :image_id)
+  end
 end

--- a/app/models/collection_template.rb
+++ b/app/models/collection_template.rb
@@ -6,4 +6,27 @@ class CollectionTemplate < ApplicationRecord
   belongs_to :collection
   belongs_to :image, optional: true
   has_many :image_templates
+
+  cattr_accessor :form_steps do
+    %w(
+      select_collection
+      select_image
+    )
+  end
+
+  ##
+  # TODO: Unimplemented form steps to add:
+  # crop_image
+  # clean_image
+  # create_image_templates
+  # create_image_paths
+  # view_image_graph
+
+  attr_accessor :form_step
+
+  # TODO: Add step by step validations here
+  # Step by step validations
+  # An example
+  # validates :image_id, presence: true,
+  #                      if: -> { required_for_step?(:select_image) }
 end

--- a/app/models/collection_template.rb
+++ b/app/models/collection_template.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# ActiveRecord model for the CollectionTemplate
+class CollectionTemplate < ApplicationRecord
+  belongs_to :collection
+  belongs_to :image, optional: true
+  has_many :image_templates
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,6 @@
 class Image < ApplicationRecord
   has_and_belongs_to_many :collections
+  has_many :collection_templates
   validates :file_name, uniqueness: true
 
   def self.from_file_path(path)

--- a/app/views/collection_templates/_collection_template.json.jbuilder
+++ b/app/views/collection_templates/_collection_template.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! collection_template, :id, :created_at, :updated_at
+json.url collection_template_url(collection_template, format: :json)

--- a/app/views/collection_templates/build/select_collection.html.erb
+++ b/app/views/collection_templates/build/select_collection.html.erb
@@ -1,0 +1,13 @@
+Select a collection
+
+<%= form_for @collection_template, method: :put, url: wizard_path do |f| %>
+  <% if f.object.errors.any? %>
+    <div class="error_messages">
+      <% f.object.errors.full_messages.each do |error| %>
+        <p><%= error %></p>
+      <% end %>
+    </div>
+  <% end %>
+  <%= f.collection_select :collection_id, Collection.all, :id, :name %>
+  <%= f.submit 'Next Step' %>
+<% end %>

--- a/app/views/collection_templates/build/select_image.html.erb
+++ b/app/views/collection_templates/build/select_image.html.erb
@@ -1,0 +1,13 @@
+Select an image
+
+<%= form_for @collection_template, method: :put, url: wizard_path do |f| %>
+  <% if f.object.errors.any? %>
+    <div class="error_messages">
+      <% f.object.errors.full_messages.each do |error| %>
+        <p><%= error %></p>
+      <% end %>
+    </div>
+  <% end %>
+  <%= f.collection_select :image_id, @collection_template.collection.images, :id, :file_name %>
+  <%= f.submit 'Next Step' %>
+<% end %>

--- a/app/views/collection_templates/index.html.erb
+++ b/app/views/collection_templates/index.html.erb
@@ -12,6 +12,7 @@
   <tbody>
     <% @collection_templates.each do |collection_template| %>
       <tr>
+        <td><%= collection_template.to_s %></td>
         <td><%= link_to 'Show', collection_template %></td>
         <td><%= link_to 'Destroy', collection_template, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>

--- a/app/views/collection_templates/index.html.erb
+++ b/app/views/collection_templates/index.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<h1>collection Templates</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @collection_templates.each do |collection_template| %>
+      <tr>
+        <td><%= link_to 'Show', collection_template %></td>
+        <td><%= link_to 'Destroy', collection_template, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New collection Template', new_collection_template_path %>

--- a/app/views/collection_templates/index.json.jbuilder
+++ b/app/views/collection_templates/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @collection_templates, partial: 'collection_templates/collection_template', as: :collection_template

--- a/app/views/collection_templates/new.html.erb
+++ b/app/views/collection_templates/new.html.erb
@@ -1,5 +1,5 @@
 <h1>New collection Template</h1>
 
-<%= render 'form', collection_template: @collection_template %>
+<%= link_to 'Build a Collection Template', collection_templates_path, method: :post %>
 
 <%= link_to 'Back', collection_templates_path %>

--- a/app/views/collection_templates/new.html.erb
+++ b/app/views/collection_templates/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New collection Template</h1>
+
+<%= render 'form', collection_template: @collection_template %>
+
+<%= link_to 'Back', collection_templates_path %>

--- a/app/views/collection_templates/show.html.erb
+++ b/app/views/collection_templates/show.html.erb
@@ -1,0 +1,3 @@
+<p id="notice"><%= notice %></p>
+
+<%= link_to 'Back', collection_templates_path %>

--- a/app/views/collection_templates/show.html.erb
+++ b/app/views/collection_templates/show.html.erb
@@ -1,3 +1,7 @@
 <p id="notice"><%= notice %></p>
 
+<div>
+  <%= @collection_template.to_json %>
+</div>
+
 <%= link_to 'Back', collection_templates_path %>

--- a/app/views/collection_templates/show.json.jbuilder
+++ b/app/views/collection_templates/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "collection_templates/collection_template", collection_template: @collection_template

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Rails.application.routes.draw do
   mount Riiif::Engine => '/image-service', as: 'riiif'
 
   # Resourceful routes for CollectionTemplates
-  resources :collection_templates, only: [:new, :create, :show, :index]
+  resources :collection_templates, only: [:new, :create, :show, :index, :destroy] do
+    resources :build,
+              only: [:show, :update], controller: 'collection_templates/build'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,7 @@ Rails.application.routes.draw do
 
   # IIIF Image API Endpoint
   mount Riiif::Engine => '/image-service', as: 'riiif'
+
+  # Resourceful routes for CollectionTemplates
+  resources :collection_templates, only: [:new, :create, :show, :index]
 end

--- a/db/migrate/20161121230301_create_collection_templates.rb
+++ b/db/migrate/20161121230301_create_collection_templates.rb
@@ -1,0 +1,13 @@
+class CreateCollectionTemplates < ActiveRecord::Migration[5.0]
+  def change
+    create_table :collection_templates do |t|
+      t.references :collection, foreign_key: true
+      t.text :crop_bounds
+      t.text :image_clean
+      t.text :image_paths
+      t.text :image_graph
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20161122140745_add_image_to_collection_template.rb
+++ b/db/migrate/20161122140745_add_image_to_collection_template.rb
@@ -1,0 +1,5 @@
+class AddImageToCollectionTemplate < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :collection_templates, :image, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161121190141) do
+ActiveRecord::Schema.define(version: 20161122140745) do
+
+  create_table "collection_templates", force: :cascade do |t|
+    t.integer  "collection_id"
+    t.text     "crop_bounds"
+    t.text     "image_clean"
+    t.text     "image_paths"
+    t.text     "image_graph"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.integer  "image_id"
+    t.index ["collection_id"], name: "index_collection_templates_on_collection_id"
+    t.index ["image_id"], name: "index_collection_templates_on_image_id"
+  end
 
   create_table "collections", force: :cascade do |t|
     t.string   "name"

--- a/spec/controllers/collection_template_controller_spec.rb
+++ b/spec/controllers/collection_template_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe CollectionTemplateController, type: :controller do
-
-end

--- a/spec/controllers/collection_template_controller_spec.rb
+++ b/spec/controllers/collection_template_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CollectionTemplateController, type: :controller do
+
+end

--- a/spec/controllers/collection_templates/build_controller_spec.rb
+++ b/spec/controllers/collection_templates/build_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionTemplates::BuildController, type: :controller do
+  describe 'GET #show' do
+    let(:collection_template) { create(:collection_template) }
+    it 'returns http success' do
+      get :show, params: {
+        id: 'select_collection',
+        collection_template_id: collection_template.id
+      }
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:collection_template) { create(:collection_template) }
+    let(:collection) { create(:collection) }
+    it 'redirects to next step' do
+      put :update, params: {
+        id: 'select_collection',
+        collection_template_id: collection_template.id,
+        collection_template: {
+          collection_id: collection.id
+        }
+      }
+      expect(response).to redirect_to(
+        collection_template_build_path(
+          assigns(:collection_template), 'select_image'
+        )
+      )
+    end
+  end
+  describe '#finish_wizard_path' do
+    let(:collection_template) { create(:collection_template) }
+    it 'returns the collection_template_path' do
+      subject.instance_variable_set('@collection_template', collection_template)
+      expect(subject.finish_wizard_path)
+        .to eq collection_template_path(collection_template)
+    end
+  end
+end

--- a/spec/controllers/collection_templates_controller_spec.rb
+++ b/spec/controllers/collection_templates_controller_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionTemplatesController, type: :controller do
+  describe 'GET index' do
+    let(:collection_templates) { create_list(:collection_template, 5) }
+    it 'assigns @collection_templates' do
+      get :index
+      expect(assigns(:collection_templates)).to eq collection_templates
+    end
+    it 'renders index' do
+      get :index
+      expect(response).to render_template('index')
+    end
+  end
+  describe 'GET show' do
+    let(:collection_template) { create(:collection_template) }
+    it 'assigns @collection_template' do
+      get :show, params: { id: collection_template.id }
+      expect(assigns(:collection_template)).to eq collection_template
+    end
+    it 'renders show' do
+      get :show, params: { id: collection_template.id }
+      expect(response).to render_template('show')
+    end
+  end
+  describe 'GET new' do
+    it 'assigns @collection_template' do
+      get :new
+      expect(assigns(:collection_template)).to be_an CollectionTemplate
+    end
+    it 'renders new' do
+      get :new
+      expect(response).to render_template('new')
+    end
+  end
+  describe 'POST create' do
+    it 'assigns @collection_template' do
+      post :create
+      expect(assigns(:collection_template)).to be_an CollectionTemplate
+    end
+    it 'redirects to collection_template_build' do
+      post :create
+      expect(subject).to redirect_to(
+        collection_template_build_path(
+          assigns(:collection_template), 'select_collection'
+        )
+      )
+    end
+  end
+  describe 'DELETE destroy' do
+    let(:collection_template) { create(:collection_template) }
+    it 'destroys @collection_template' do
+      delete :destroy, params: { id: collection_template.id }
+      expect { collection_template.reload }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+    context 'when html' do
+      it 'redirects to collection_templates_url' do
+        delete :destroy, params: { id: collection_template.id }
+        expect(subject).to redirect_to collection_templates_url
+      end
+    end
+    context 'when json' do
+      it 'renders nothing' do
+        delete :destroy, params: { id: collection_template.id, format: :json }
+        expect(response.body).to eq ''
+      end
+    end
+  end
+end

--- a/spec/factories/collection_template.rb
+++ b/spec/factories/collection_template.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :collection_template do
+    collection
+    factory :collection_template_with_image do
+      image
+    end
+  end
+end

--- a/spec/features/collection_template_builder_spec.rb
+++ b/spec/features/collection_template_builder_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Collection Template Builder', type: :feature do
+  describe 'step by step building' do
+    before do
+      images = create_list(:image, 5)
+      create(:collection, images: images)
+    end
+    it 'renders and creates consecutive form steps' do
+      visit new_collection_template_path
+      click_link 'Build a Collection Template'
+      click_button 'Next Step'
+      click_button 'Next Step'
+      # Just a basic show page with some json rendered
+      expect(page).to have_css 'body', text: '{"id":'
+    end
+    it 'increments CollectionTemplate' do
+      expect do
+        visit new_collection_template_path
+        click_link 'Build a Collection Template'
+        click_button 'Next Step'
+        click_button 'Next Step'
+      end.to change { CollectionTemplate.count }.by(1)
+    end
+  end
+end

--- a/spec/models/collection_template_spec.rb
+++ b/spec/models/collection_template_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CollectionTemplate, type: :model do
+  it 'must belong to a collection' do
+    expect { described_class.create! }
+      .to raise_error(ActiveRecord::RecordInvalid)
+  end
+  it 'can have an image' do
+    expect(create(:collection_template_with_image).image).to be_an Image
+  end
+end


### PR DESCRIPTION
Closes #25 

This PR lays the groundwork for the step by step approach to building a `CollectionTemplate`. This PR adds in basic templates for `select_collection` and `select_image`, but is extendable by [appending to `CollectionTemplate.form_steps`](https://github.com/sul-cidr/histonets/compare/build-steps?expand=1#diff-597967e38410ff78a8f3d3056115cd96R6).

![collectiontemp](https://cloud.githubusercontent.com/assets/1656824/20540978/3fc2debc-b0c9-11e6-8537-7b40226f497c.gif)
