### PR TITLE
ignore vendor stylesheets

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -5,6 +5,8 @@ ruby:
 scss:
   enabled: true
   config_file: .scss-lint.yml
+  exclude:
+    - 'vendor/assets/stylesheets/**'
 
 eslint:
   enabled: true


### PR DESCRIPTION
So that our vendor scss/css files do not need to be style checked by hound