### PR TITLE
Provide the id, and allow for a string or number

### DIFF
--- a/app/assets/javascripts/components/image_template_viewer.es6.jsx
+++ b/app/assets/javascripts/components/image_template_viewer.es6.jsx
@@ -15,6 +15,11 @@ class ImageTemplateViewer extends React.Component {
           name={`collection_template[image_templates_attributes][${this.props.id}][image_url]`}
           value={this.props.image_url}
         />
+        <input
+          type="hidden"
+          name={`collection_template[image_templates_attributes][${this.props.id}][id]`}
+          value={this.props.id}
+        />
       </li>
     );
   }
@@ -22,7 +27,10 @@ class ImageTemplateViewer extends React.Component {
 
 ImageTemplateViewer.propTypes = {
   image_url: React.PropTypes.string,
-  id: React.PropTypes.string,
+  id: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number,
+  ]),
 };
 
 ImageTemplateViewer.defaultProps = {


### PR DESCRIPTION
Fixes a bug where image templates could be duplicated because the
id was not present in the form submission.

without supplying the id.. the `PUT update` will recreate the exact same `image_template`