### PR TITLE
Refactor histograms to support image paths

### DIFF
--- a/app/assets/javascripts/components/image_template_container.es6.jsx
+++ b/app/assets/javascripts/components/image_template_container.es6.jsx
@@ -20,7 +20,7 @@ class ImageTemplateContainer extends React.Component {
   }
 
   regionToImageUrl(region) {
-    return `${this.props.iiifImage.replace('/info.json', '')}/${region.join(',')}/full/0/default.jpg`;
+    return `${this.props.iiifImage.replace('/info.json', '')}/${region.join(',')}/full/0/default.png`;
   }
 
   render() {

--- a/app/controllers/collection_templates/build_controller.rb
+++ b/app/controllers/collection_templates/build_controller.rb
@@ -37,8 +37,10 @@ class CollectionTemplates::BuildController < ApplicationController
     case step
     when 'auto_clean'
       ImageEnhanceJob.new.perform(@collection_template)
+      @collection_template.calculate_histogram
     when 'image_clean'
       ImageCleanJob.new.perform(@collection_template)
+      @collection_template.calculate_histogram
     when 'create_image_templates'
       @collection_template.unverify_image_templates
     end

--- a/app/jobs/calculate_histogram_job.rb
+++ b/app/jobs/calculate_histogram_job.rb
@@ -5,8 +5,11 @@
 class CalculateHistogramJob < ApplicationJob
   queue_as :default
 
-  def perform(image)
-    histogram = Histogram.find_or_create_by!(image: image)
+  def perform(histogramable)
+    histogram = Histogram.find_or_create_by!(
+      histogramable_id: histogramable.id,
+      histogramable_type: histogramable.class.name
+    )
     histogram.extract_and_parse_histogram
   end
 end

--- a/app/models/collection_template.rb
+++ b/app/models/collection_template.rb
@@ -6,6 +6,10 @@ class CollectionTemplate < ApplicationRecord
   belongs_to :collection
   belongs_to :image, optional: true
   has_many :image_templates, dependent: :destroy
+  has_one :histogram, dependent: :destroy, as: :histogramable
+
+  # Used by Histogram to figure out where the file is
+  delegate :file_name, to: :cleaned_image
 
   accepts_nested_attributes_for :image_templates,
                                 reject_if: :reject_image_templates

--- a/app/models/collection_template.rb
+++ b/app/models/collection_template.rb
@@ -9,7 +9,7 @@ class CollectionTemplate < ApplicationRecord
   has_one :histogram, dependent: :destroy, as: :histogramable
 
   # Used by Histogram to figure out where the file is
-  delegate :file_name, to: :cleaned_image
+  alias_attribute :file_name, :cleaned_file_name
 
   accepts_nested_attributes_for :image_templates,
                                 reject_if: :reject_image_templates
@@ -56,6 +56,10 @@ class CollectionTemplate < ApplicationRecord
     "#{fingerprinted_name}_tmp"
   end
 
+  def cleaned_file_name
+    "#{cleaned_image}.#{Settings.DEFAULT_IMAGE_EXTENSION}"
+  end
+
   def fingerprinted_name
     Digest::MD5.hexdigest(
       [
@@ -73,7 +77,8 @@ class CollectionTemplate < ApplicationRecord
     "#{Riiif::Engine.routes.url_helpers.image_path(
       image.file_name_no_extension,
       region: crop_bounds,
-      size: 'full'
+      size: 'full',
+      format: Settings.DEFAULT_IMAGE_EXTENSION
     )}"
   end
 
@@ -87,6 +92,10 @@ class CollectionTemplate < ApplicationRecord
   # Set all `image_templates` as unverified|false
   def unverify_image_templates
     image_templates.map { |it| it.update(status: false) }
+  end
+
+  def calculate_histogram
+    CalculateHistogramJob.perform_later(self)
   end
 
   private

--- a/app/models/histogram.rb
+++ b/app/models/histogram.rb
@@ -6,8 +6,8 @@
 class Histogram < ApplicationRecord
   include ActiveSupport::Benchmarkable
 
-  belongs_to :image
-  delegate :file_name, to: :image
+  belongs_to :histogramable, polymorphic: true
+  delegate :file_name, to: :histogramable
 
   ##
   # Extracts, parses, and saves the histogram

--- a/app/models/histogram.rb
+++ b/app/models/histogram.rb
@@ -12,37 +12,8 @@ class Histogram < ApplicationRecord
   ##
   # Extracts, parses, and saves the histogram
   def extract_and_parse_histogram
-    raw_output = nil
-    logger.info("Extracting histogram from #{file_name}")
-    benchmark("Extracted histogram from #{file_name}") do
-      raw_output = extract_histogram
-    end
-    logger.info("Parsing and saving histogram #{file_name}")
-    benchmark('Parsed and saved histogram') do
-      # Store the Histogram as JSON (but saving as binary for performance)
-      self.histogram = Histogram.parse_histogram(raw_output).to_json
-      save
-    end
-  end
-
-  ##
-  # For a given image, extract the histogram from ImageMagick
-  def extract_histogram
-    Riiif::File.new("#{Settings.IMAGE_PATH}/#{file_name}")
-               .extract(
-                 format: '-define histogram:unique-colors=true -format %c'\
-                   ' histogram:info'
-               )
-  end
-
-  ##
-  # Parses raw output from ImageMagick histogram into a Hash
-  def self.parse_histogram(raw_output)
-    raw_output.each_line.map do |line|
-      [
-        /\([0-9]*,[0-9]*,[0-9]*\)/.match(line.delete(' '))[0],
-        /[0-9]*:/.match(line)[0].sub(':', '')
-      ]
-    end.to_h
+    self.histogram = HistogramExtractor.new(file_name)
+                                       .extract_and_parse_histogram
+    save
   end
 end

--- a/app/models/histogram_extractor.rb
+++ b/app/models/histogram_extractor.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+##
+# Class for extracting histograms
+class HistogramExtractor
+  include ActiveSupport::Benchmarkable
+
+  delegate :logger, to: :Rails
+
+  attr_reader :file_name
+
+  def initialize(file_name)
+    @file_name = file_name
+  end
+
+  ##
+  # Extracts, parses, and saves the histogram
+  def extract_and_parse_histogram
+    raw_output = nil
+    logger.info("Extracting histogram from #{file_name}")
+    benchmark("Extracted histogram from #{file_name}") do
+      raw_output = extract_histogram
+    end
+    logger.info("Parsing and saving histogram #{file_name}")
+    benchmark('Parsed and saved histogram') do
+      # Store the Histogram as JSON (but saving as binary for performance)
+      HistogramExtractor.parse_histogram(raw_output).to_json
+    end
+  end
+
+  ##
+  # For a given image, extract the histogram from ImageMagick
+  def extract_histogram
+    Riiif::File.new("#{Settings.IMAGE_PATH}/#{file_name}")
+               .extract(
+                 format: '-define histogram:unique-colors=true -format %c'\
+                   ' histogram:info'
+               )
+  end
+
+  ##
+  # Parses raw output from ImageMagick histogram into a Hash
+  def self.parse_histogram(raw_output)
+    raw_output.each_line.map do |line|
+      [
+        /\([0-9]*,[0-9]*,[0-9]*\)/.match(line.delete(' '))[0],
+        /[0-9]*:/.match(line)[0].sub(':', '')
+      ]
+    end.to_h
+  end
+end

--- a/app/models/histonets_cv/cli.rb
+++ b/app/models/histonets_cv/cli.rb
@@ -8,10 +8,11 @@ module HistonetsCv
 
     delegate :logger, to: :Rails
 
-    attr_reader :file_name
+    attr_reader :file_name, :extension
 
-    def initialize(file_name = '')
+    def initialize(file_name = '', extension = 'png')
       @file_name = file_name
+      @extension = extension
     end
 
     def contrast(value)
@@ -73,7 +74,7 @@ module HistonetsCv
     def output(hash)
       "-o #{Settings.IMAGE_PATH}/"\
       "#{File.basename(file_name, File.extname(file_name))}_#{hash}_tmp"\
-      "#{File.extname(file_name)}"
+      ".#{extension}"
     end
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,7 +1,7 @@
 class Image < ApplicationRecord
   has_and_belongs_to_many :collections
   has_many :collection_templates
-  has_one :histogram, dependent: :destroy
+  has_one :histogram, dependent: :destroy, as: :histogramable
   validates :file_name, uniqueness: true
 
   after_commit :calculate_histogram, on: :create

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,3 @@
 HOST_URL: "http://localhost:3000"
 IMAGE_PATH: 'spec/fixtures/images'
+DEFAULT_IMAGE_EXTENSION: 'png'

--- a/db/migrate/20170117212158_histograms_to_polymorphic.rb
+++ b/db/migrate/20170117212158_histograms_to_polymorphic.rb
@@ -1,0 +1,8 @@
+class HistogramsToPolymorphic < ActiveRecord::Migration[5.0]
+  def change
+    remove_reference :histograms, :iamge
+    change_table :histograms do |t|
+      t.references :histogramable, polymorphic: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170117230102) do
+ActiveRecord::Schema.define(version: 20170117212158) do
 
   create_table "collection_templates", force: :cascade do |t|
     t.integer  "collection_id"
@@ -44,8 +44,11 @@ ActiveRecord::Schema.define(version: 20170117230102) do
   create_table "histograms", force: :cascade do |t|
     t.integer  "image_id"
     t.binary   "histogram"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "histogramable_type"
+    t.integer  "histogramable_id"
+    t.index ["histogramable_type", "histogramable_id"], name: "index_histograms_on_histogramable_type_and_histogramable_id"
     t.index ["image_id"], name: "index_histograms_on_image_id"
   end
 

--- a/spec/factories/histogram.rb
+++ b/spec/factories/histogram.rb
@@ -2,6 +2,5 @@
 
 FactoryGirl.define do
   factory :histogram do
-    image
   end
 end

--- a/spec/features/image_clean_spec.rb
+++ b/spec/features/image_clean_spec.rb
@@ -46,15 +46,30 @@ RSpec.describe 'Image clean', type: :feature, js: true do
         expect(CollectionTemplate.last.image_clean)
           .to eq('posterize' => '0', 'posterize_method' => 'kmeans')
       end
+      it 'enqueues the histogram calculation' do
+        ActiveJob::Base.queue_adapter = :test
+        find('[for="collection_template_image_clean_posterize_enabled"]').click
+        expect(page).to have_xpath '//input[@name="'\
+          'collection_template[image_clean][posterize_method]"]'
+        expect do
+          click_button 'Next Step'
+        end.to have_enqueued_job(CalculateHistogramJob)
+      end
     end
   end
   context 'auto cleaning' do
     before do
       check 'collection_template_auto_clean'
-      click_button 'Next Step'
     end
     it 'saves and sets auto_clean' do
+      click_button 'Next Step'
       expect(CollectionTemplate.last.auto_clean).to be true
+    end
+    it 'enqueues the histogram calculation' do
+      ActiveJob::Base.queue_adapter = :test
+      expect do
+        click_button 'Next Step'
+      end.to have_enqueued_job(CalculateHistogramJob)
     end
   end
 end

--- a/spec/jobs/image_clean_job_spec.rb
+++ b/spec/jobs/image_clean_job_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe ImageCleanJob, type: :job do
       expect(cli_instance).to receive(:pipeline)
         .with(
           '[{"action":"contrast","options":{"value":42}}]',
-          'http://localhost:1337/image-service/eddie/0,0,100,100/full/0/default.jpg',
-          '633219bbc6c560b58d55a1f4960e56cd'
+          'http://localhost:1337/image-service/eddie/0,0,100,100/full/0/default.png',
+          '82fa8cd8b2eacfe3c12695d8cbb54838'
         )
       subject.perform(collection_template)
     end

--- a/spec/models/collection_template_spec.rb
+++ b/spec/models/collection_template_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe CollectionTemplate, type: :model do
     end
     it 'returns a MD5 hashed value of name, crop_bounds, and image_clean' do
       expect(subject.fingerprinted_name)
-        .to eq '383843602aa6372e03b5343c2ae8c9db'
+        .to eq '5045802809d18d1e73953eeccdf130dd'
     end
   end
   describe '#cropped_image' do

--- a/spec/models/histogram_extractor_spec.rb
+++ b/spec/models/histogram_extractor_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HistogramExtractor, type: :model do
+  describe '#extract_histogram' do
+    subject(:generic_histogram) do
+      described_class.new('yolo.jpg')
+    end
+    let(:riiif_instance) { instance_double(Riiif::File) }
+    it 'receives file_name from relation and calls extract' do
+      expect(Riiif::File).to receive(:new)
+        .with('spec/fixtures/images/yolo.jpg').and_return(riiif_instance)
+      expect(riiif_instance).to receive(:extract).with(
+        format: '-define histogram:unique-colors=true -format %c histogram:info'
+      )
+      generic_histogram.extract_histogram
+    end
+  end
+  describe '.parse_histogram' do
+    let(:raw_input) do
+      "     18: (162,129, 50) #A28132 srgb(162,129,50)\n"\
+      "     14: (162,142,107) #A28E6B srgb(162,142,107)\n"\
+      "     1: (162,142,141) #A28E8D srgb(162,142,141)\n"
+    end
+    subject(:parsed_response) { described_class.parse_histogram(raw_input) }
+    it 'returns a hash from a raw string' do
+      expect(parsed_response).to be_an Hash
+    end
+    it 'each line is a key,value pair' do
+      expect(parsed_response.count).to eq 3
+    end
+    it 'keys are the rgb colors without whitespace' do
+      expect(parsed_response.keys).to include('(162,129,50)')
+    end
+    it 'values are the counts' do
+      expect(parsed_response.values).to include('18')
+    end
+  end
+end

--- a/spec/models/histogram_spec.rb
+++ b/spec/models/histogram_spec.rb
@@ -4,8 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Histogram, type: :model do
   describe '#extract_and_parse_histogram' do
+    let(:histogramable) { create(:image, file_name: 'yolo.jpg') }
     subject(:generic_histogram) do
-      create(:histogram, image: create(:image, file_name: 'yolo.jpg'))
+      create(
+        :histogram,
+        histogramable_id: histogramable.id,
+        histogramable_type: 'Image'
+      )
     end
     let(:extractor) { instance_double(HistogramExtractor) }
     it 'extracts and saves a histogram' do

--- a/spec/models/histogram_spec.rb
+++ b/spec/models/histogram_spec.rb
@@ -3,38 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Histogram, type: :model do
-  describe '#extract_histogram' do
+  describe '#extract_and_parse_histogram' do
     subject(:generic_histogram) do
       create(:histogram, image: create(:image, file_name: 'yolo.jpg'))
     end
-    let(:riiif_instance) { instance_double(Riiif::File) }
-    it 'receives file_name from relation and calls extract' do
-      expect(Riiif::File).to receive(:new)
-        .with('spec/fixtures/images/yolo.jpg').and_return(riiif_instance)
-      expect(riiif_instance).to receive(:extract).with(
-        format: '-define histogram:unique-colors=true -format %c histogram:info'
-      )
-      generic_histogram.extract_histogram
-    end
-  end
-  describe '.parse_histogram' do
-    let(:raw_input) do
-      "     18: (162,129, 50) #A28132 srgb(162,129,50)\n"\
-      "     14: (162,142,107) #A28E6B srgb(162,142,107)\n"\
-      "     1: (162,142,141) #A28E8D srgb(162,142,141)\n"
-    end
-    subject(:parsed_response) { described_class.parse_histogram(raw_input) }
-    it 'returns a hash from a raw string' do
-      expect(parsed_response).to be_an Hash
-    end
-    it 'each line is a key,value pair' do
-      expect(parsed_response.count).to eq 3
-    end
-    it 'keys are the rgb colors without whitespace' do
-      expect(parsed_response.keys).to include('(162,129,50)')
-    end
-    it 'values are the counts' do
-      expect(parsed_response.values).to include('18')
+    let(:extractor) { instance_double(HistogramExtractor) }
+    it 'extracts and saves a histogram' do
+      expect(HistogramExtractor).to receive(:new)
+        .with('yolo.jpg').and_return(extractor)
+      expect(extractor).to receive(:extract_and_parse_histogram).and_return({
+        fake: :histogram
+      }.to_json)
+      generic_histogram.extract_and_parse_histogram
+      expect(generic_histogram.histogram).to eq '{"fake":"histogram"}'
     end
   end
 end

--- a/spec/models/histonets_cv/cli_spec.rb
+++ b/spec/models/histonets_cv/cli_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe HistonetsCv::Cli, type: :model do
     it 'executes the contrast command with arguments' do
       expect(subject).to receive(:execute)
         .with('contrast 42 file://spec/fixtures/images/yolo.jpg -o '\
-              'spec/fixtures/images/yolo_contrast_tmp.jpg')
+              'spec/fixtures/images/yolo_contrast_tmp.png')
       subject.contrast(42)
     end
   end
@@ -26,7 +26,7 @@ RSpec.describe HistonetsCv::Cli, type: :model do
     it 'executes the brightness command with arguments' do
       expect(subject).to receive(:execute)
         .with('brightness 42 file://spec/fixtures/images/yolo.jpg -o '\
-              'spec/fixtures/images/yolo_brightness_tmp.jpg')
+              'spec/fixtures/images/yolo_brightness_tmp.png')
       subject.brightness(42)
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe HistonetsCv::Cli, type: :model do
     it 'executes the pipeline command with json arguments' do
       expect(subject).to receive(:execute)
         .with("pipeline '#{arguments}' file://spec/fixtures/images/yolo.jpg "\
-              '-o spec/fixtures/images/yolo__tmp.jpg')
+              '-o spec/fixtures/images/yolo__tmp.png')
       subject.pipeline(arguments)
     end
   end


### PR DESCRIPTION
Closes #111 and unblocks #104 

Sets `png` as our preferred extension for cleaned / enhanced images