### PR TITLE
Fixes a type in a migration by adding a new migration

### DIFF
--- a/db/migrate/20170117212158_histograms_to_polymorphic.rb
+++ b/db/migrate/20170117212158_histograms_to_polymorphic.rb
@@ -1,6 +1,6 @@
 class HistogramsToPolymorphic < ActiveRecord::Migration[5.0]
   def change
-    remove_reference :histograms, :iamge
+    remove_reference :histograms, :image
     change_table :histograms do |t|
       t.references :histogramable, polymorphic: true, index: true
     end

--- a/db/migrate/20170119132559_remove_column_image_from_histogram.rb
+++ b/db/migrate/20170119132559_remove_column_image_from_histogram.rb
@@ -1,0 +1,7 @@
+class RemoveColumnImageFromHistogram < ActiveRecord::Migration[5.0]
+  def change
+    if column_exists? :histograms, :image_id
+      remove_reference :histograms, :image
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170117212158) do
+ActiveRecord::Schema.define(version: 20170119132559) do
 
   create_table "collection_templates", force: :cascade do |t|
     t.integer  "collection_id"
@@ -42,14 +42,12 @@ ActiveRecord::Schema.define(version: 20170117212158) do
   end
 
   create_table "histograms", force: :cascade do |t|
-    t.integer  "image_id"
     t.binary   "histogram"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
     t.string   "histogramable_type"
     t.integer  "histogramable_id"
     t.index ["histogramable_type", "histogramable_id"], name: "index_histograms_on_histogramable_type_and_histogramable_id"
-    t.index ["image_id"], name: "index_histograms_on_image_id"
   end
 
   create_table "image_templates", force: :cascade do |t|


### PR DESCRIPTION
I made a mistake in a previous migration which causes migration on some databases to fail (our deployed postgres). This should fix things up.