### PR TITLE
use __ separator for env vars on deployment

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -12,7 +12,7 @@ Config.setup do |config|
 
   # Load environment variables from the `ENV` object and override any settings defined in files.
   #
-  # config.use_env = false
+  config.use_env = true
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
@@ -22,15 +22,15 @@ Config.setup do |config|
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
   # using dots in variable names might not be allowed (eg. Bash).
   #
-  # config.env_separator = '.'
+  config.env_separator = '__'
 
   # Ability to process variables names:
   #   * nil  - no change
   #   * :downcase - convert to lower case
   #
-  # config.env_converter = :downcase
+  config.env_converter = nil
 
   # Parse numeric values as integers instead of strings.
   #
-  # config.env_parse_values = true
+  config.env_parse_values = true
 end


### PR DESCRIPTION
Because of the way that we are doing env vars on the server, we need to change the separator so the server can pick up correct env vars. 

cc @tallenaz @eefahy 

Tested successfully on server.