### PR TITLE
initialize tooltips that are not part of a react component

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,0 +1,5 @@
+/* globals $, document */
+
+$(document).on('turbolinks:load', () => {
+  $('[data-toggle="tooltip"]').tooltip();
+});


### PR DESCRIPTION
Yikes I missed this before, but tooltips that aren't getting initialized in React will get missed.