### PR TITLE
Disable rubocop rule for build_controller

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
+
+Style/SymbolArray:
+  Exclude:
+    - 'app/controllers/collection_templates/*'


### PR DESCRIPTION
This PR disables the Style/SymbolArray for the build_controller. While we could have fixed the code to follow the rule, we've repeatedly chosen not to, so it makes sense to simply disable it for that file. 